### PR TITLE
Sprite animation now allows beginFrame and add relative background scroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ CTestTestfile.cmake
 *.exe
 *.out
 *.app
+
+#VisualStudio code
+.vscode

--- a/engine/include/libgba-sprite-engine/background/background.h
+++ b/engine/include/libgba-sprite-engine/background/background.h
@@ -25,9 +25,10 @@ public:
     const int getCharBlock() { return charBlockIndex; }
     void useMapScreenBlock(int block) { screenBlockIndex = block; }
     void scroll(int x, int y);
+    void scrollSpeed(int dx, int dy);
 
     Background(int bgIndex, const void *data, int size, const void* map, int mapSize) : data(data), bgIndex(bgIndex), size(size), map(map),
-                                                                       screenBlockIndex(0), charBlockIndex(0), mapSize(mapSize) {}
+                                                                                        screenBlockIndex(0), charBlockIndex(0), mapSize(mapSize) {}
     virtual void persist();
     void updateMap(const void* map);
     void clearMap();

--- a/engine/include/libgba-sprite-engine/sprites/sprite.h
+++ b/engine/include/libgba-sprite-engine/sprites/sprite.h
@@ -58,7 +58,7 @@ protected:
     bool stayWithinBounds;
     u32 imageSize, tileIndex;
     SpriteSize spriteSize;
-    u32 animationDelay, amountOfFrames, beginFrame, currentFrame, animationCounter;
+    u32 animationDelay, numberOfFrames, beginFrame, currentFrame, animationCounter;
     bool animating;
 
     std::unique_ptr<OBJ_ATTR> oam;
@@ -73,13 +73,13 @@ public:
     explicit Sprite(const void *imageData, int imageSize, int x, int y, SpriteSize size);
     virtual ~Sprite() {}
 
-    void makeAnimated(int amountOfFrames, int animationDelay) {
-        this->amountOfFrames = amountOfFrames;
+    void makeAnimated(int numberOfFrames, int animationDelay) {
+        this->numberOfFrames = numberOfFrames;
         this->animationDelay = animationDelay;
         animate();
     }
-    void makeAnimated(int beginFrame, int amountOfFrames, int animationDelay) {
-        this->amountOfFrames = amountOfFrames;
+    void makeAnimated(int beginFrame, int numberOfFrames, int animationDelay) {
+        this->numberOfFrames = numberOfFrames;
         this->animationDelay = animationDelay;
         this->beginFrame = beginFrame;
         this->currentFrame = beginFrame;

--- a/engine/include/libgba-sprite-engine/sprites/sprite.h
+++ b/engine/include/libgba-sprite-engine/sprites/sprite.h
@@ -58,7 +58,7 @@ protected:
     bool stayWithinBounds;
     u32 imageSize, tileIndex;
     SpriteSize spriteSize;
-    u32 animationDelay, amountOfFrames, currentFrame, animationCounter;
+    u32 animationDelay, amountOfFrames, beginFrame, currentFrame, animationCounter;
     bool animating;
 
     std::unique_ptr<OBJ_ATTR> oam;
@@ -76,6 +76,13 @@ public:
     void makeAnimated(int amountOfFrames, int animationDelay) {
         this->amountOfFrames = amountOfFrames;
         this->animationDelay = animationDelay;
+        animate();
+    }
+    void makeAnimated(int beginFrame, int amountOfFrames, int animationDelay) {
+        this->amountOfFrames = amountOfFrames;
+        this->animationDelay = animationDelay;
+        this->beginFrame = beginFrame;
+        this->currentFrame = beginFrame;
         animate();
     }
     void animate() { this->animating = true; }
@@ -107,6 +114,7 @@ public:
     u32 getWidth() { return w; }
     u32 getY() { return y; }
     u32 getCurrentFrame() { return currentFrame; }
+    bool isAnimating() { return animating; };
     bool isOffScreen();
 
     friend class SpriteManager;

--- a/engine/include/libgba-sprite-engine/sprites/sprite.h
+++ b/engine/include/libgba-sprite-engine/sprites/sprite.h
@@ -79,14 +79,14 @@ public:
         animate();
     }
     void makeAnimated(int beginFrame, int numberOfFrames, int animationDelay) {
-        this->numberOfFrames = numberOfFrames;
-        this->animationDelay = animationDelay;
-        this->beginFrame = beginFrame;
-        this->currentFrame = beginFrame;
+        setBeginFrame(beginFrame);
+        animateToFrame(beginFrame);
+        makeAnimated(numberOfFrames, animationDelay);
         animate();
     }
-    void animate() { this->animating = true; }
+    void setBeginFrame(int frame) { this->beginFrame = frame; }
     void animateToFrame(int frame) { this->currentFrame = frame; }
+    void animate() { this->animating = true; }
     void stopAnimating() { this->animating = false; }
     void setStayWithinBounds(bool b) { stayWithinBounds = b; }
     void setVelocity(int dx, int dy) {

--- a/engine/include/libgba-sprite-engine/sprites/sprite.h
+++ b/engine/include/libgba-sprite-engine/sprites/sprite.h
@@ -107,12 +107,12 @@ public:
     GBAVector getPosAsVector() { return GBAVector(getPos()); }
     VECTOR getCenter() { return { x + w / 2, y + h / 2 }; }
     VECTOR getVelocity() { return { dx, dy}; }
+    u32 getX() { return x; }
+    u32 getY() { return y; }
     u32 getDx() { return dx; }
     u32 getDy() { return dy; }
-    u32 getX() { return x; }
-    u32 getHeight() { return h; }
     u32 getWidth() { return w; }
-    u32 getY() { return y; }
+    u32 getHeight() { return h; }
     u32 getCurrentFrame() { return currentFrame; }
     bool isAnimating() { return animating; };
     bool isOffScreen();

--- a/engine/include/libgba-sprite-engine/sprites/sprite_builder.h
+++ b/engine/include/libgba-sprite-engine/sprites/sprite_builder.h
@@ -13,12 +13,12 @@ private:
     bool stayWithinBounds = false;
     const void *imageData;
     u32 x, y, dx, dy;
-    u32 numberOfFrames, animationDelay;
+    u32 beginFrame, numberOfFrames, animationDelay;
     SpriteSize size;
 
     void setProperties(T* sprite);
     void reset() {
-        imageSize = x = y = dx = dy = numberOfFrames = animationDelay = 0;
+        imageSize = x = y = dx = dy = beginFrame = numberOfFrames = animationDelay = 0;
         imageData = nullptr;
         stayWithinBounds = false;
         size = SIZE_16_16;
@@ -51,9 +51,16 @@ public:
         this->size = size;
         return *this;
     }
-    SpriteBuilder& withAnimated(int numberOfFrames, int delay) {
+    SpriteBuilder& withAnimated(int numberOfFrames, int animationDelay) {
+        this->beginFrame = 0;
         this->numberOfFrames = numberOfFrames;
-        this->animationDelay = delay;
+        this->animationDelay = animationDelay;
+        return *this;
+    }
+    SpriteBuilder& withAnimated(int beginFrame, int numberOfFrames, int animationDelay) {
+        this->beginFrame = beginFrame;
+        this->numberOfFrames = numberOfFrames;
+        this->animationDelay = animationDelay;
         return *this;
     }
     T build();
@@ -73,7 +80,11 @@ template<typename T> std::unique_ptr<T> SpriteBuilder<T>::buildWithDataOf(const 
 template<typename T> void SpriteBuilder<T>::setProperties(T* s) {
     s->setVelocity(this->dx, this->dy);
     if(this->numberOfFrames > 0) {
-        s->makeAnimated(this->numberOfFrames, this->animationDelay);
+        if(this->beginFrame > 0) {
+            s->makeAnimated(this->beginFrame, this->numberOfFrames, this->animationDelay);
+        } else {
+            s->makeAnimated(this->numberOfFrames, this->animationDelay);
+        }
     }
     s->setStayWithinBounds(stayWithinBounds);
 

--- a/engine/src/background/background.cpp
+++ b/engine/src/background/background.cpp
@@ -79,3 +79,8 @@ void Background::scroll(int x, int y) {
     REG_BG_OFS[bgIndex].x = x;
     REG_BG_OFS[bgIndex].y = y;
 }
+
+void Background::scrollSpeed(int dx, int dy) {
+    REG_BG_OFS[bgIndex].x += dx;
+    REG_BG_OFS[bgIndex].y += dy;
+}

--- a/engine/src/sprites/sprite.cpp
+++ b/engine/src/sprites/sprite.cpp
@@ -14,7 +14,7 @@ Sprite::Sprite(const Sprite &other) : Sprite(nullptr, 0, other.x, other.y, other
 
 Sprite::Sprite(const void *imageData, int imageSize, int x, int y, SpriteSize size)
         : x(x), y(y), data(imageData), imageSize(imageSize), spriteSize(size),
-          animationDelay(0), amountOfFrames(0), beginFrame(0), currentFrame(0), animationCounter(0) {
+          animationDelay(0), numberOfFrames(0), beginFrame(0), currentFrame(0), animationCounter(0) {
     setAttributesBasedOnSize(size);
 }
 
@@ -86,7 +86,7 @@ void Sprite::updateAnimation() {
     animationCounter++;
     if(animationCounter > animationDelay) {
         currentFrame++;
-        if(currentFrame > (amountOfFrames - 1) + beginFrame) {
+        if(currentFrame > (numberOfFrames - 1) + beginFrame) {
             currentFrame = beginFrame;
         }
         if(currentFrame < beginFrame) {

--- a/engine/src/sprites/sprite.cpp
+++ b/engine/src/sprites/sprite.cpp
@@ -14,7 +14,7 @@ Sprite::Sprite(const Sprite &other) : Sprite(nullptr, 0, other.x, other.y, other
 
 Sprite::Sprite(const void *imageData, int imageSize, int x, int y, SpriteSize size)
         : x(x), y(y), data(imageData), imageSize(imageSize), spriteSize(size),
-          animationDelay(0), amountOfFrames(0), currentFrame(0), animationCounter(0) {
+          animationDelay(0), amountOfFrames(0), beginFrame(0), currentFrame(0), animationCounter(0) {
     setAttributesBasedOnSize(size);
 }
 
@@ -86,8 +86,11 @@ void Sprite::updateAnimation() {
     animationCounter++;
     if(animationCounter > animationDelay) {
         currentFrame++;
-        if(currentFrame > (amountOfFrames - 1)) {
-            currentFrame = 0;
+        if(currentFrame > (amountOfFrames - 1) + beginFrame) {
+            currentFrame = beginFrame;
+        }
+        if(currentFrame < beginFrame) {
+            currentFrame = beginFrame;
         }
 
         animationCounter = 0;


### PR DESCRIPTION
Added/updated functions to make it possible to choose a start frame.
Used overloading for backwards compatibility.
Also add a getter to check if the sprite is currently animating.
Sorted functions and fixed grammar (number of frames is countable, so not 'amount').
And finally, added a function for relative scroll of backgrounds.