### PR TITLE
Fix sprite priority

### DIFF
--- a/engine/src/sprites/sprite.cpp
+++ b/engine/src/sprites/sprite.cpp
@@ -13,7 +13,7 @@ Sprite::Sprite(const Sprite &other) : Sprite(nullptr, 0, other.x, other.y, other
 }
 
 Sprite::Sprite(const void *imageData, int imageSize, int x, int y, SpriteSize size)
-        : x(x), y(y), data(imageData), imageSize(imageSize), spriteSize(size),
+        : x(x), y(y), data(imageData), imageSize(imageSize), spriteSize(size), priority(0),
           animationDelay(0), numberOfFrames(0), beginFrame(0), currentFrame(0), animationCounter(0) {
     setAttributesBasedOnSize(size);
 }


### PR DESCRIPTION
After A LOT of frustration because of missing sprites, I found the issue and fixed it.

I already noticed in some scenes the missing sprites could be seen behind some pixels when moving it around, as if the sprite is there (it is, I verified with the 'View sprites...'-tool of mGBA) but just hidden behind the background.

However, sprites should be drawn over the background, I fixed this by setting the priority (like a background layer) to 0.